### PR TITLE
Service account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ doc: swagger
 	swagger serve pkg/swagger/swagger.yaml
 
 test_dr: build
-	GOOS=$(GOOS) GO111MODULE=$(GO111MODULE) DR_GATEWAY_CONFIG=$(DR_GATEWAY_CONFIG) go test -v github.com/dccn-tg/dr-gateway/pkg/dr/... 
+	GOOS=$(GOOS) GO111MODULE=$(GO111MODULE) DR_GATEWAY_CONFIG=$(DR_GATEWAY_CONFIG) go test -v -count=1 github.com/dccn-tg/dr-gateway/pkg/dr/... 
 
 clean:
 	rm -rf bin

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,8 +6,6 @@ dr:
   irodsHost: icat.localhost
   irodsPort: 1247
   irodsZone: nl.ru.donders
-  irodsUser: user
-  irodsPass: pass
   irodsAuthScheme: native
   irodsSslCacert: /opt/irods/ssl/icat-prod.pem
   irodsSslKeysize: 32
@@ -15,7 +13,9 @@ dr:
   irodsSslSaltSize: 8
   irodsHashRounds: 16
   organisationalUnits:
-    - DCCN
-    - DCC
-    - DCN
-    - DCMN
+    - name: DCCN
+      irodsUser: user
+      irodsPass: pass
+    - name: DCC
+      irodsUser: user
+      irodsPass: pass

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/cyverse/go-irodsclient v0.12.7
 	github.com/dccn-tg/tg-toolset-golang v1.21.0
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/loads v0.21.2
 	github.com/go-openapi/runtime v0.25.0
@@ -26,7 +27,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect

--- a/internal/api-server/handler/collections_cache.go
+++ b/internal/api-server/handler/collections_cache.go
@@ -70,6 +70,13 @@ func (c *CollectionsCache) refresh() {
 	}
 }
 
+// UpdateConfig updates configuration data
+func (c *CollectionsCache) UpdateConfig(cfg config.Configuration) {
+	c.mutex.Lock()
+	c.Config = cfg
+	c.mutex.Unlock()
+}
+
 // GetCollections returns all collections from cache
 func (c *CollectionsCache) GetCollections() []*dr.DRCollection {
 

--- a/internal/api-server/handler/users_cache.go
+++ b/internal/api-server/handler/users_cache.go
@@ -70,6 +70,13 @@ func (c *UsersCache) refresh() {
 	}
 }
 
+// UpdateConfig updates configuration data
+func (c *UsersCache) UpdateConfig(cfg config.Configuration) {
+	c.mutex.Lock()
+	c.Config = cfg
+	c.mutex.Unlock()
+}
+
 // GetUsers returns all users from cache
 func (c *UsersCache) GetUsers() []*dr.DRUser {
 

--- a/pkg/dr/collection.go
+++ b/pkg/dr/collection.go
@@ -203,6 +203,13 @@ func getCollections(accounts map[string]*types.IRODSAccount, cpaths chan ouPath)
 			// initialized connections is kept in the map for reuse.
 			conns := make(map[string]*connection.IRODSConnection)
 
+			// closing up all connections
+			defer func() {
+				for _, conn := range conns {
+					conn.Disconnect()
+				}
+			}()
+
 		collLoop:
 			for p := range cpaths {
 				c := new(DRCollection)
@@ -258,11 +265,6 @@ func getCollections(accounts map[string]*types.IRODSAccount, cpaths chan ouPath)
 					}
 					colls <- c
 				}
-			}
-
-			// closing up all connections
-			for _, conn := range conns {
-				conn.Disconnect()
 			}
 		}()
 	}

--- a/pkg/dr/init.go
+++ b/pkg/dr/init.go
@@ -18,7 +18,15 @@ type Config struct {
 	IrodsSslAlgorithm   string
 	IrodsSslSaltSize    int
 	IrodsHashRounds     int
-	OrganisationalUnits []string
+	OrganisationalUnits []ServiceAccount
+}
+
+// ServiceAccount defines the configuration data structure for
+// OU-specific service account data-access credential.
+type ServiceAccount struct {
+	Name      string
+	IrodsUser string
+	IrodsPass string
 }
 
 func (c Config) AuthSchemeType() types.AuthScheme {
@@ -32,6 +40,8 @@ func (c Config) AuthSchemeType() types.AuthScheme {
 	}
 }
 
+// NewAccount returned a configured `types.IRODSAccount` iRODS client that is
+// ready for making iRODS connections.
 func NewAccount(config Config) (*types.IRODSAccount, error) {
 
 	account, err := types.CreateIRODSAccount(
@@ -66,23 +76,14 @@ func NewAccount(config Config) (*types.IRODSAccount, error) {
 	return account, nil
 }
 
-func NewProxyAccount(config Config, user string) (*types.IRODSAccount, error) {
+// NewServiceAccounts returned a map of configured `types.IRODSAccount` iRODS clients that is
+// ready for making iRODS connections.
+//
+// The key of the map is the organizational unit name provided by the `config.OrganizationalUnits`;
+// and the value is the iRODS client initiated with the organizational unit's service account credential.
+func NewServiceAccounts(config Config) (map[string]*types.IRODSAccount, error) {
 
-	account, err := types.CreateIRODSProxyAccount(
-		config.IrodsHost,
-		config.IrodsPort,
-		user,
-		config.IrodsZone,
-		config.IrodsUser,
-		config.IrodsZone,
-		config.AuthSchemeType(),
-		config.IrodsPass,
-		"",
-	)
-
-	if err != nil {
-		return nil, err
-	}
+	accounts := make(map[string]*types.IRODSAccount)
 
 	sslConfig, err := types.CreateIRODSSSLConfig(
 		config.IrodsSslCacert,
@@ -91,13 +92,32 @@ func NewProxyAccount(config Config, user string) (*types.IRODSAccount, error) {
 		config.IrodsSslSaltSize,
 		config.IrodsHashRounds,
 	)
+
 	if err != nil {
 		return nil, err
 	}
 
-	account.SSLConfiguration = sslConfig
-	account.CSNegotiationPolicy = types.CSNegotiationRequireSSL
-	account.ClientServerNegotiation = true
+	for _, sa := range config.OrganisationalUnits {
+		account, err := types.CreateIRODSAccount(
+			config.IrodsHost,
+			config.IrodsPort,
+			sa.IrodsUser,
+			config.IrodsZone,
+			config.AuthSchemeType(),
+			sa.IrodsPass,
+			"",
+		)
 
-	return account, nil
+		if err != nil {
+			return nil, err
+		}
+
+		account.SSLConfiguration = sslConfig
+		account.CSNegotiationPolicy = types.CSNegotiationRequireSSL
+		account.ClientServerNegotiation = true
+
+		accounts[sa.Name] = account
+	}
+
+	return accounts, nil
 }

--- a/pkg/dr/user.go
+++ b/pkg/dr/user.go
@@ -4,10 +4,10 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/dccn-tg/tg-toolset-golang/pkg/logger"
 	"github.com/cyverse/go-irodsclient/irods/connection"
 	"github.com/cyverse/go-irodsclient/irods/fs"
 	"github.com/cyverse/go-irodsclient/irods/types"
+	log "github.com/dccn-tg/tg-toolset-golang/pkg/logger"
 )
 
 type DRUser struct {
@@ -18,9 +18,22 @@ type DRUser struct {
 }
 
 func GetAllUsers(config Config) (chan *DRUser, error) {
+
+	// general iRODS account
 	acc, err := NewAccount(config)
 	if err != nil {
 		return nil, err
+	}
+
+	// use the first service account if specified
+	accounts, err := NewServiceAccounts(config)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, account := range accounts {
+		acc = account
+		break
 	}
 
 	uids := make(chan string, 10000)

--- a/pkg/dr/user_test.go
+++ b/pkg/dr/user_test.go
@@ -27,29 +27,31 @@ func initLogger() {
 // load configuration to DRConfig structure
 func loadDRConfig(cpath string) (Config, error) {
 
-	var conf Config
+	var conf struct {
+		Dr Config
+	}
 
 	// load configuration
 	cfg, err := filepath.Abs(cpath)
 	if err != nil {
-		return conf, err
+		return conf.Dr, err
 	}
 
 	if _, err := os.Stat(cfg); err != nil {
-		return conf, fmt.Errorf("cannot load config: %s", cfg)
+		return conf.Dr, fmt.Errorf("cannot load config: %s", cfg)
 	}
 
 	viper.SetConfigFile(cfg)
 	if err := viper.ReadInConfig(); err != nil {
-		return conf, fmt.Errorf("cannot read config file, %s", err)
+		return conf.Dr, fmt.Errorf("cannot read config file, %s", err)
 	}
 
 	err = viper.Unmarshal(&conf)
 	if err != nil {
-		return conf, fmt.Errorf("unable to decode into struct, %v", err)
+		return conf.Dr, fmt.Errorf("unable to decode into struct, %v", err)
 	}
 
-	return conf, nil
+	return conf.Dr, nil
 }
 
 func TestGetAllUsers(t *testing.T) {


### PR DESCRIPTION
@Jascha-N could you please help to review this change?  The change is to make use of the RDR service account recently delivered by the RU RDR team.  This replaces the current situation where the general iRODS admin account is used for querying RDR collection and user metadata.

If you prefer, I can also go through the changes with you.